### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/HTTP/Client.pm6
+++ b/lib/HTTP/Client.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class HTTP::Client;
+unit class HTTP::Client;
 
 our $VERSION = '0.2'; ## The version of HTTP::Client.
 

--- a/lib/HTTP/Client/Request.pm6
+++ b/lib/HTTP/Client/Request.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class HTTP::Client::Request;
+unit class HTTP::Client::Request;
 
 ## This is the request class. It represents a request to an HTTP server.
 

--- a/lib/HTTP/Client/Response.pm6
+++ b/lib/HTTP/Client/Response.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class HTTP::Client::Response;
+unit class HTTP::Client::Response;
 
 ## This is the response class. It represents a response from an HTTP server.
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.