### PR TITLE
.send has been removed, use .print

### DIFF
--- a/lib/HTTP/Client.pm6
+++ b/lib/HTTP/Client.pm6
@@ -99,7 +99,7 @@ method do-request (HTTP::Client::Request $request, :$follow=0) {
 #  $*ERR.say: "Connecting to '$host' on '$port'";
 
   my $sock = IO::Socket::INET.new(:$host, :$port);
-  $sock.send(~$request);
+  $sock.print(~$request);
   my $resp;
   my $chunk;
   repeat {


### PR DESCRIPTION
This fixes HTTP-Client, which dies as .send has been removed with all the other pre-RC0 deprecated methods.