### PR TITLE
Use http.perl6.org in tests

### DIFF
--- a/t/01-get.t
+++ b/t/01-get.t
@@ -5,7 +5,7 @@ use Test;
 plan 6;
 
 my $http = HTTP::Client.new;
-my $res = $http.get('http://perl6.org/');
+my $res = $http.get('http://http.perl6.org/');
 #my $res = $http.get('http://127.0.0.1:8080/test.txt');
 #$*ERR.say: "~Status: "~$res.status;
 #$*ERR.say: "~Message: "~$res.message;

--- a/t/02-post.t
+++ b/t/02-post.t
@@ -8,7 +8,7 @@ my $http = HTTP::Client.new;
 #my $res = $htto.get('http://huri.net/test.txt');
 my $req = $http.post;
 #$req.url('http://127.0.0.1:8080/test.txt');
-$req.url('http://perl6.org');
+$req.url('http://http.perl6.org');
 $req.add-field(:query<libwww-perl>, :mode<dist>);
 my $res = $req.run;
 #$*ERR.say: "~Status: "~$res.status;

--- a/t/03-post-multipart.t
+++ b/t/03-post-multipart.t
@@ -8,7 +8,7 @@ my $http = HTTP::Client.new;
 #my $res = $htto.get('http://huri.net/test.txt');
 my $req = $http.post(:multipart);
 #$req.url('http://127.0.0.1:8080/test.txt');
-$req.url('http://perl6.org');
+$req.url('http://http.perl6.org');
 $req.add-field(:id<1984>);
 $req.add-file(
   :name("upload"),     :filename("test.txt"), 


### PR DESCRIPTION
The main perl6.org site will soon get a redirecto to HTTPS, while
http.perl6.org will remain available as plain HTTP.