### PR TITLE
Allow Content-Type to be set

### DIFF
--- a/lib/HTTP/Client/Request.pm6
+++ b/lib/HTTP/Client/Request.pm6
@@ -290,7 +290,6 @@ method Str {
   }
   ## Okay, add the headers.
   for @!headers -> $header {
-    if $header.key eq 'Content-Type' { next; }
     $output ~= "{$header.key}: {$header.value}$CRLF";
   }
   if $!data {


### PR DESCRIPTION
the removed line filtered out the "$!type" that was added to the headers just before, I presume the filtering was from a point in time when the $!type was added differently...